### PR TITLE
ci(github): add issue templates and chooser config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a defect or unexpected behavior
+title: "bug(scope): short title"
+labels: bug
+assignees: ""
+type: Bug
+---
+
+## Summary
+
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Environment
+- OS:
+- Python:
+- Version / commit:
+
+## Notes

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/somnio-kimm/telling_by_faice/security/advisories/new
+    about: Please report security issues privately, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose a small, actionable improvement
+title: "feat(scope): short title"
+labels: enhancement
+assignees: ""
+type: Feature
+---
+
+## Objective
+
+
+## Background
+
+## Tasks
+- [ ] 
+- [ ] 
+
+## Acceptance Criteria
+- [ ] 
+- [ ] 
+
+## Notes


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/bug_report_template.md` (Summary / Steps / Expected / Actual / Environment)
- Adds `.github/ISSUE_TEMPLATE/feature_request_template.md` (Objective / Background / Tasks / Acceptance Criteria / Notes)
- Adds `.github/ISSUE_TEMPLATE/config.yml` disabling blank issues and pointing security reports at the private advisory form

## Why
REVIEW.md rule 10 requires linked issues to include reproduction context; baking that into the templates makes it the default instead of something reviewers chase after.

## Test plan
- [ ] Open https://github.com/somnio-kimm/telling_by_faice/issues/new and confirm both templates appear in the chooser
- [ ] Blank-issue option is hidden
- [ ] Security contact link resolves to the private advisory form
- [ ] Titles are pre-filled as `bug(scope): ...` and `feat(scope): ...`

Closes #1