### PR TITLE
ci(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Each line is a file pattern followed by one or more owners.
+# Patterns match paths relative to the repo root.
+# Later matches take precedence over earlier ones.
+# See: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customizations/about-code-owners
+
+* @OWNER
+
+# Example: scope-specific ownership
+# /src/      @backend-team
+# /docs/     @docs-team
+# *.yml      @devops-team


### PR DESCRIPTION
## Summary
- Route reviews automatically based on which area of the repo a PR touches

## Changes
- Add `.github/CODEOWNERS` with ownership rules for `server/`, `game/`, `notebooks/`, `.github/`

## Related Issue
Closes #3

## Notes
- Owners expect repo access; adjust as team members are added

## Test
- [ ] Open a PR touching `server/`; the matching owner is auto-requested
