### PR TITLE
ci(github): add copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+# Copilot Review Instructions
+
+This repository uses `REVIEW.md` as the primary policy for AI-based PR reviews.
+
+## Instructions
+
+- Follow `REVIEW.md` for all feature PR reviews.
+- Follow `REVIEW.md` for branch naming, commit message, and PR title conventions.
+- Write all review output in English.
+- Keep feedback concrete, actionable, and within the current feature scope.


### PR DESCRIPTION
## Summary
- Guide GitHub Copilot to follow the same review policy as Claude

## Changes
- Add `.github/copilot-instructions.md` mirroring CLAUDE.md (follow REVIEW.md, English output, in-scope feedback)

## Related Issue
Closes #5

## Notes
-

## Test
- [ ] File picked up by Copilot in this repo
