### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thanks for helping improve this project.
+
+## Conventions
+
+Branch names, commit messages, and PR titles follow the rules in [REVIEW.md](REVIEW.md).
+
+## Development setup
+
+```bash
+make install
+```
+
+Python tooling lives in `server/` — `uv` commands run from there. Prefer the root `Makefile` targets.
+
+## Before opening a PR
+
+```bash
+make pre-commit
+make test
+```
+
+- Open PRs against `dev`.
+- Use the PR template; fill in every section.
+- Link the related issue with `Closes #<n>` when applicable.
+
+## Issues
+
+- **Bugs** — use the bug report template.
+- **Features** — use the feature request template.
+- **Security** — do NOT open a public issue. See [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
## Summary
- Document the contributor dev loop and PR conventions

## Changes
- Add `CONTRIBUTING.md` with dev loop (`make install` -> `make pre-commit` -> `make test`), PR base branch (`dev`), `Closes #<n>` convention, links to REVIEW.md and SECURITY.md

## Related Issue
Closes #12

## Notes
-

## Test
- [ ] Referenced from README
- [ ] Links resolve
