### PR TITLE
docs: add CLAUDE.md repository instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Claude Repository Instructions
+
+This repository uses `REVIEW.md` as the primary policy for AI-based PR reviews.
+
+## Instructions
+
+- Follow `REVIEW.md` for all feature PR reviews.
+- Follow `REVIEW.md` for branch naming, commit message, and PR title conventions.
+- Write all review output in English.
+- Keep feedback concrete, actionable, and within the current feature scope.


### PR DESCRIPTION
## Summary
- Tell Claude to follow REVIEW.md for reviews and naming

## Changes
- Add root `CLAUDE.md` with review instructions (follow REVIEW.md, English output, concrete and in-scope feedback)

## Related Issue
Closes #14

## Notes
-

## Test
- [ ] Claude Code picks it up automatically in the repo
