### PR TITLE
chore(repo): add .dockerignore and .env.example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.venv
+checkpoints
+data

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=


### PR DESCRIPTION
## Summary
- Add `.dockerignore` and `.env.example`

## Changes
- Add `.dockerignore` excluding `.git`, `.venv`, caches, `models/`, `notebooks/`
- Add `.env.example` with `OPENAI_API_KEY=`

## Related Issue
Closes #18

## Notes
-

## Test
- [ ] `cp .env.example .env` bootstraps a working config for the backend
