### PR TITLE
chore(tooling): add root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: install lint format test pre-commit build clean server
+
+install:
+	cd server && uv sync --all-extras --dev
+	cd server && uv run pre-commit install
+
+lint:
+	cd server && uv run ruff check .
+
+format:
+	cd server && uv run ruff format .
+	cd server && uv run ruff check --fix .
+
+test:
+	cd server && uv run pytest --strict-markers -m "not manual"
+
+pre-commit:
+	cd server && uv run pre-commit run --all-files
+
+build:
+	cd server && uv build
+
+server:
+	cd server && uv run uvicorn faice.main:app --reload
+
+clean:
+	rm -rf server/.pytest_cache server/.ruff_cache server/.mypy_cache server/build server/dist server/*.egg-info
+	find . -type d -name __pycache__ -exec rm -rf {} +


### PR DESCRIPTION
## Summary
- Single entrypoint for common dev tasks

## Changes
- Add root `Makefile` with targets: `install`, `lint`, `format`, `test`, `pre-commit`, `build`, `server`, `clean`, delegating into `server/`

## Related Issue
Closes #19

## Notes
- Some targets (`test`, `server`, `build`) require the `server/` package to land first

## Test
- [ ] Each target runs end-to-end once the server package is in place
