### PR TITLE
feat(server): add config module (faice.config)

### DIFF
--- a/server/src/faice/config.py
+++ b/server/src/faice/config.py
@@ -1,0 +1,21 @@
+"""Runtime constants for the emotion pipeline."""
+
+from pathlib import Path
+
+import torch
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+MODELS_DIR = Path(__file__).resolve().parents[3] / "models"
+DETECTOR_PATH = MODELS_DIR / "yolo.onnx"
+CLASSIFIER_WEIGHT_PATH = MODELS_DIR / "efficientnet_b3.pth"
+
+EMOTION = ["anger", "happy", "panic", "sadness"]
+EMOTION_MAP = {
+    "anger": "angry",
+    "happy": "happy",
+    "panic": "awe",
+    "sadness": "sad",
+    "blank": "blank",
+}
+IMAGE_SIZE = 300


### PR DESCRIPTION
## Summary
- Centralize env and path configuration in `faice.config`

## Changes
- Add `server/src/faice/config.py` loading `.env` and exposing `OPENAI_API_KEY` and model weight paths

## Related Issue
Closes #23

## Notes
- No scattered `os.environ` reads elsewhere in `faice/`

## Test
- [ ] Missing required env var raises a clear error on startup
