### PR TITLE
feat(game): initialize Godot 4 project

### DIFF
--- a/game/.editorconfig
+++ b/game/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+charset = utf-8

--- a/game/.gitattributes
+++ b/game/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf

--- a/game/.gitignore
+++ b/game/.gitignore
@@ -1,0 +1,3 @@
+# Godot 4+ specific ignores
+.godot/
+/android/

--- a/game/project.godot
+++ b/game/project.godot
@@ -1,0 +1,26 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="fAIce"
+run/main_scene="uid://dro0tcsr7e0l5"
+config/features=PackedStringArray("4.4", "Forward Plus")
+
+[autoload]
+
+camera_display="*res://globals/camera_display.tscn"
+heart="*res://globals/heart.tscn"
+
+[display]
+
+window/size/viewport_width=1440
+window/size/viewport_height=900
+window/autoload_on_startup=false


### PR DESCRIPTION
## Summary
- Initialize the Godot 4 project

## Changes
- Add `game/project.godot`
- Add `game/.editorconfig`, `game/.gitattributes`, `game/.gitignore`

## Related Issue
Closes #28

## Notes
- Empty `addons/`, `assets/`, `data/`, `globals/`, `scenes/` directories will be populated by subsequent PRs

## Test
- [ ] Godot 4.4+ opens the project without errors
