### PR TITLE
feat(game): add title scene

### DIFF
--- a/game/scenes/title/title.gd
+++ b/game/scenes/title/title.gd
@@ -1,0 +1,25 @@
+extends Control
+@onready var bgm_player = $bgm_player
+
+func _ready():
+	bgm_player.play()
+	$button/story_mode.pressed.connect(_on_story_mode_pressed)
+	$button/interactive_mode.pressed.connect(_on_interactive_mode_pressed)
+	$button/credits.pressed.connect(_on_credits_pressed)
+	$button/exit.pressed.connect(_on_exit_pressed)
+
+func _on_story_mode_pressed():
+	print("Game start")
+	get_tree().change_scene_to_file("res://scenes/stage/stage.tscn")
+
+func _on_interactive_mode_pressed():
+	print("Game start")
+	get_tree().change_scene_to_file("res://scenes/stage/stage.tscn")
+
+func _on_credits_pressed():
+	print("Credit")
+	get_tree().change_scene_to_file("res://scenes/credits/credits.tscn")
+
+func _on_exit_pressed():
+	print("Exit")
+	get_tree().quit()

--- a/game/scenes/title/title.gd.uid
+++ b/game/scenes/title/title.gd.uid
@@ -1,0 +1,1 @@
+uid://chd0gxfi1v5ly

--- a/game/scenes/title/title.tscn
+++ b/game/scenes/title/title.tscn
@@ -1,0 +1,64 @@
+[gd_scene load_steps=4 format=3 uid="uid://dro0tcsr7e0l5"]
+
+[ext_resource type="Script" uid="uid://chd0gxfi1v5ly" path="res://scenes/title/title.gd" id="1_0xm2m"]
+[ext_resource type="Texture2D" uid="uid://bfc7uyeyyvkm" path="res://assets/images/shared/background_title.png" id="2_o71fo"]
+[ext_resource type="AudioStream" uid="uid://nnyqql8rhjcp" path="res://assets/sounds/title.ogg" id="3_m7x51"]
+
+[node name="title" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_0xm2m")
+
+[node name="background" type="TextureRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("2_o71fo")
+
+[node name="button" type="VBoxContainer" parent="."]
+z_index = 1
+y_sort_enabled = true
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -150.0
+offset_top = -150.0
+offset_right = 150.0
+offset_bottom = -50.0
+grow_horizontal = 2
+grow_vertical = 0
+alignment = 1
+
+[node name="story_mode" type="Button" parent="button"]
+custom_minimum_size = Vector2(300, 40)
+layout_mode = 2
+text = "Story Mode"
+
+[node name="interactive_mode" type="Button" parent="button"]
+custom_minimum_size = Vector2(300, 40)
+layout_mode = 2
+text = "Interactive Mode"
+
+[node name="credits" type="Button" parent="button"]
+custom_minimum_size = Vector2(300, 40)
+layout_mode = 2
+text = "Credits"
+
+[node name="exit" type="Button" parent="button"]
+custom_minimum_size = Vector2(300, 40)
+layout_mode = 2
+text = "Exit"
+
+[node name="bgm_player" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("3_m7x51")
+volume_db = 1.0


### PR DESCRIPTION
## Summary
- Title scene with start button routing to the first stage

## Changes
- Add `game/scenes/title/title.tscn`
- Add `game/scenes/title/title.gd` and `title.gd.uid`

## Related Issue
Closes #29

## Notes
-

## Test
- [ ] Launching the project shows the title
- [ ] Start button transitions to `stage.tscn`
