### PR TITLE
feat(game): add heart autoload singleton

### DIFF
--- a/game/globals/heart.gd
+++ b/game/globals/heart.gd
@@ -1,0 +1,28 @@
+extends Control
+
+signal hearts_depleted
+
+@onready var hearts_container := $hearts_container
+
+var hearts: Array
+var hearts_curr: int = -1
+
+func _ready():
+	hearts = hearts_container.get_children()
+	if hearts_curr == -1:
+		hearts_curr = hearts.size()
+	update_heart(hearts_curr)
+
+func lose_heart(heart_loss: int = 0):
+	hearts_curr -= heart_loss
+	print("💔 Hearts remaining: ", hearts_curr)
+	update_heart(hearts_curr)
+	if hearts_curr <= 0:
+		emit_signal("hearts_depleted")
+
+func update_heart(value: int):
+	for i in range(hearts.size()):
+		hearts[i].visible = i < value
+		
+func get_remaining_hearts() -> int:
+	return hearts_curr

--- a/game/globals/heart.gd.uid
+++ b/game/globals/heart.gd.uid
@@ -1,0 +1,1 @@
+uid://dn51kiy6s75d4

--- a/game/globals/heart.tscn
+++ b/game/globals/heart.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=3 format=3 uid="uid://bs0nrdk0b2mj1"]
+
+[ext_resource type="Script" uid="uid://dn51kiy6s75d4" path="res://globals/heart.gd" id="1_v4rw2"]
+[ext_resource type="Texture2D" uid="uid://c1626r2cpnxu3" path="res://assets/images/shared/chicken_breast.png" id="2_r34uj"]
+
+[node name="heart" type="Control"]
+layout_direction = 3
+layout_mode = 3
+anchors_preset = 0
+scale = Vector2(0.133665, 0.136934)
+script = ExtResource("1_v4rw2")
+
+[node name="hearts_container" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 19.72
+anchor_bottom = 17.998
+offset_left = -59.0
+offset_top = -155.0
+offset_right = 188.2
+offset_bottom = 149.08
+
+[node name="heart_0" type="TextureRect" parent="hearts_container"]
+layout_mode = 2
+texture = ExtResource("2_r34uj")
+
+[node name="heart_1" type="TextureRect" parent="hearts_container"]
+layout_mode = 2
+texture = ExtResource("2_r34uj")
+
+[node name="heart_2" type="TextureRect" parent="hearts_container"]
+layout_mode = 2
+texture = ExtResource("2_r34uj")
+
+[node name="heart_3" type="TextureRect" parent="hearts_container"]
+layout_mode = 2
+texture = ExtResource("2_r34uj")


### PR DESCRIPTION
## Summary
- HP tracking autoload singleton

## Changes
- Add `game/globals/heart.gd`, `heart.tscn`, `heart.gd.uid`
- Register `Heart` autoload in `project.godot`

## Related Issue
Closes #34

## Notes
- API exposes `decrement`, `reset`, and current HP

## Test
- [ ] Stage transitions preserve HP
- [ ] Decrements persist between scenes
