### PR TITLE
feat(game): add dialogue data under data/dialogues/

### DIFF
--- a/game/data/dialogues/stage_0_intro.json
+++ b/game/data/dialogues/stage_0_intro.json
@@ -1,0 +1,14 @@
+{
+	"bgm": "res://assets/sounds/intro.ogg",
+	"dialogue": [
+		{
+			"text": "(요즘 집에 틀어박혀 코드만 짜다 보니, 운동을 너무 안 하게 됐어...)",
+			"background": "res://assets/images/shared/background_title.png",
+		},
+		
+		{
+			"text": "(몸이 건강해야 일도 잘되지... 헬스장 등록부터 해야겠다.)",
+			"background": "res://assets/images/shared/background_title.png",
+		}
+	]
+}

--- a/game/data/dialogues/stage_0_main.json
+++ b/game/data/dialogues/stage_0_main.json
@@ -1,0 +1,131 @@
+{
+	"bgm": "res://assets/sounds/battle_default.ogg",
+	"dialogue": [
+		{
+			"text": "엇, 새로 오신 분인가?",
+			"background": "res://assets/images/shared/background_intro.png"
+		},
+		
+		{
+			"text": "Dgym에 잘 오셨습니다! 이 동네에 우리 집만큼 기구 좋고 가격 착한 곳 없어요~",
+			"background": "res://assets/images/stage_0/sitting_1.png"
+		},
+		
+		{
+			"text": "회원과 트레이너들이 조금 독특한 거 빼곤...",
+			"background": "res://assets/images/stage_0/sitting_2.png"
+		},
+		
+		{
+			"text": "여기 회원과 트레이너들은 말에 진심이야. 무시당하면 상처받는다고!",
+			"background": "res://assets/images/stage_0/sitting_3.png"
+		},
+		
+		{
+			"text": "나도 그랬다가... 하하, 아픈 기억이지.",
+			"background": "res://assets/images/stage_0/sitting_2.png"
+		},
+		
+		{
+			"text": "그래서 말할 때는 표정을 잘 지어야 해! 자, 한 번 테스트해 보자.",
+			"background": "res://assets/images/stage_0/sitting_1.png"
+		},
+		
+		{
+			"text": "자, 내 말이 끝나면 왼쪽 위에 타이머가 돌아갈 거야. 지금처럼!",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/default.png",
+			"timer": true
+		},
+		
+		{
+			"text": "타이머가 끝나면, 내 말에 어울리는 표정을 지어줘야 해!",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/default.png"
+		},
+		
+		{
+			"text": "우선 얼굴 근육부터 스트레칭해보자!",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/happy.png"
+		},
+		
+		{
+			"text": "나처럼 기쁜 표정을 지어줘!",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/happy.png",
+			"timer": true
+		},
+		
+		{
+			"text": "(표정을 응시한다.)",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/default.png",
+			"emotion_expected": "happy",
+			"failure_text": "흠, 그게 아니지.",
+		},
+		
+		{
+			"text": "나처럼 슬픈 표정을 지어줘!",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/sad.png",
+			"timer": true
+		},
+		
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/default.png",
+			"emotion_expected": "sad",
+			"failure_text": "흠, 그게 아니지."
+		},
+		
+		{
+			"text": "자, 이제 내 이야기를 들려줄게!",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/happy.png"
+		},
+		
+		{
+			"text": "어제 요 앞에서 고양이가 차에 치였지 뭐야... 가엾은 것...",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/sad.png",
+			"timer": true
+		},
+		
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/default.png",
+			"emotion_expected": "sad",
+			"failure_text": " 내 얘기애 귀 기울이지 않는구나... 걱정이 앞서는 군..."
+		},
+		
+		{
+			"text": "그런데 구조를 해서 얼마나 다행인지 몰라",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/happy.png",
+			"timer": true
+		},
+		
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/default.png",
+			"emotion_expected": "happy",
+			"failure_text": "다시, 다시! 한 번 천천히... 내가 뭐라고 했는지 생각해 봐..."
+		},
+		
+		{
+			"text": "대충 알겠지? 아마 큰 문제는 없을 거야.",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/happy.png"
+		},
+		
+		{
+			"text": "그럼 운동 열심히 하고! 난 이만 수건 정리하러 가볼게~",
+			"background": "res://assets/images/shared/background_intro.png",
+			"character": "res://assets/images/stage_0/happy.png"
+		}
+	]
+}

--- a/game/data/dialogues/stage_1_game_over.json
+++ b/game/data/dialogues/stage_1_game_over.json
@@ -1,0 +1,15 @@
+{
+	"bgm": "res://assets/sounds/game_over.ogg",
+	"dialogue": [
+		{
+			"text": "몸 관리 좀 하지 그래? 멋진 몸이 매력인 시대라고~",
+			"character": "res://assets/images/stage_1/game_over.png",
+		},
+		
+		{
+			"text": "그 몸으론... 데이트는 좀 어렵겠는걸?",
+			"character": "res://assets/images/stage_1/game_over.png",
+			"end": true
+		}
+	]
+}

--- a/game/data/dialogues/stage_1_intro.json
+++ b/game/data/dialogues/stage_1_intro.json
@@ -1,0 +1,14 @@
+{
+	"bgm": "res://assets/sounds/intro.ogg",
+	"dialogue": [
+		{
+			"text": "(뭔가... 독...특한 헬스장인가 보다...)",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "(나가야 하나...?)",
+			"background": "res://assets/images/shared/background_main.png"
+		}
+	]
+}

--- a/game/data/dialogues/stage_1_main.json
+++ b/game/data/dialogues/stage_1_main.json
@@ -1,0 +1,108 @@
+{
+	"bgm": "res://assets/sounds/battle_default.ogg",
+	"dialogue": [
+		{
+			"text": "어, 너 새로 왔지? 여기 회원들... 진짜 몸이 장난이 아니야!",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png"
+		},
+
+		{
+			"text": "나? 트레이너 맞아. 근데... 그냥 운동만 하는 건 좀 심심하잖아?",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/happy.png"
+		},
+
+		{
+			"text": "하하! 누굴 가르치는 것도 좋지만, 관찰하는 재미도 있달까?",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png"
+		},
+
+		{
+			"text": "어제 수업 중에 회원 한 명이 어깨를 만지더라고? 시그널인가?",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/happy.png",
+			"timer": true
+		},
+		
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png",
+			"emotion_expected": "happy", 
+			"failure_text": "나 좋아하는 것 같아! 아니야? 아니냐고!",
+			"failure_background": "res://assets/images/shared/background_main.png",
+			"failure_character": "res://assets/images/stage_1/angry.png"
+		},
+
+		{
+			"text": "근데... 그 회원, 커플 운동 중이었대... 남자친구랑 말이야.",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/sad.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png",
+			"emotion_expected": "sad", 
+			"failure_text": "너 T야? 나 비웃는 거지!",
+			"failure_background": "res://assets/images/shared/background_main.png",
+			"failure_character": "res://assets/images/stage_1/angry.png"
+		},
+
+		{
+			"text": " 뭐... 오히려 좋아!",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png",
+		},
+
+		{
+			"text": "오늘 새로운 회원이 왔거든! 몸 좋다고도 했어! 나한테 관심이 있는 것 같지?",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png",
+			"emotion_expected": "happy", 
+			"failure_text": " 내 몸을 무시해? 한번 내 대흉근과 대화해 볼래?",
+			"failure_background": "res://assets/images/shared/background_main.png",
+			"failure_character": "res://assets/images/stage_1/angry.png"
+		},
+
+		{
+			"text": "근데... 나한테 한 말이 아니었어...  관장님 얘기더라...",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/sad.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png",
+			"emotion_expected": "sad", 
+			"failure_text": "웃어?",
+			"failure_background": "res://assets/images/shared/background_main.png",
+			"failure_character": "res://assets/images/stage_1/angry.png"
+		},
+		
+		{
+			"text": "괜찮아! 근육은 배신하지 않거든!",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png"
+		},
+
+		{
+			"text": "자신감이 곧 근육! 근육이 곧 매력! 난 이제 다음 회원 만나러 간다~",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_1/default.png"
+		}
+	]
+}

--- a/game/data/dialogues/stage_2_game_over.json
+++ b/game/data/dialogues/stage_2_game_over.json
@@ -1,0 +1,25 @@
+{
+	"bgm": "res://assets/sounds/game_over.ogg",
+	"dialogue": [
+		{
+			"text": "공감 능력이 결여된",
+			"character": "res://assets/images/stage_2/game_over.png"
+		},
+		
+		{
+			"text": "너 같은 사람이",
+			"character": "res://assets/images/stage_2/game_over.png"
+		},
+		
+		{
+			"text": "몸이 좋아질 리가 없잖아?",
+			"character": "res://assets/images/stage_2/game_over.png"
+		},
+		
+		{
+			"text": "닭가슴살조차 네겐 과분해!",
+			"character": "res://assets/images/stage_2/game_over.png",
+			"end": true
+		}
+	]
+}

--- a/game/data/dialogues/stage_2_intro.json
+++ b/game/data/dialogues/stage_2_intro.json
@@ -1,0 +1,19 @@
+{
+	"bgm": "res://assets/sounds/intro.ogg",
+	"dialogue": [
+		{
+			"text": "(그냥... 여자에 미친 사람이구나. 안타깝다...)",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "(운동만 끝내고 얼른 나가자...)",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "어?  처음 보는 얼굴이네~",
+			"background": "res://assets/images/shared/background_main.png"
+		}	
+	]
+}

--- a/game/data/dialogues/stage_2_main.json
+++ b/game/data/dialogues/stage_2_main.json
@@ -1,0 +1,134 @@
+{
+	"bgm": "res://assets/sounds/battle_default.ogg",
+	"dialogue": [
+		{
+			"text": "혹시 나 보러 온 거야~? 사실, 내가 좀 예쁜 걸로 유명하거든? 후후",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png"
+		},
+
+		{
+			"text": "뭐, 어쨌든 환영해!”",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/happy.png"
+		},
+
+		{
+			"text": "나한테 반하지 마. 진짜 곤란해~ 상처만 받을 거야~",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png"
+		},
+
+		{
+			"text": "(......?)",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png"
+		},
+
+		{
+			"text": "(예쁘긴 하지만... 거리를 두자...)",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png"
+		},
+
+		{
+			"text": "이번에 레깅스 하나 새로 샀는데, 어때? 나랑 잘 어울리지?",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/happy.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png",
+			"emotion_expected": "happy", 
+			"failure_text": "참나! 나 같은 몸매가 되기 쉬운줄 아니?",
+			"failure_character": "res://assets/images/stage_2/angry.png"
+		},
+
+		{
+			"text": "확실히 여기서 내가 제일 몸매가 좋긴 하지...",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png"
+		},
+
+		{
+			"text": "(... 이 여자... 자신감이... 무서울 정도다...)",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png"
+		},
+
+
+		{
+			"text": "참! 아까 어떤 남자가 내 번호 달라고 하더라? 역시, 예쁘면 피곤하다니까?",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/happy.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png",
+			"emotion_expected": "happy", 
+			"failure_text": "설마... 네 마음속에 내가 있는 건 아니지?"
+		},
+
+
+		{
+			"text": "근데... 유부남이래.  잘생겼던데...",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/sad.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png",
+			"emotion_expected": "sad", 
+			"failure_text": "왜... 웃어? 설마 너도... 날?"
+		},
+
+		{
+			"text": "그나저나 지훈이는 나한테 왜 계속 밥 먹자고 하지? 쟤... 날 좋아하나?",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/happy.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png",
+			"emotion_expected": "happy", 
+			"failure_text": "너 왜 슬픈 표정이지? 혹시 너도 날 좋아해?"
+		},
+		
+		
+		{
+			"text": "후후, 미인은 너무 피곤하네요~",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/happy.png"
+		},
+
+		{
+			"text": "(더이상 침묵으로 넘길 수 없겠어... 설명을 해야겠네...)",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png"
+		},
+
+		{
+			"text": "'지훈 트레이너와 좀전에 대화했던 내용을 전했다.'",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/default.png"
+		},
+		
+		{
+			"text": "아, 그놈이 그런 사람이었어?! 아아아! 짜증나!",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_2/sad.png"
+		}
+	]
+}

--- a/game/data/dialogues/stage_3_game_over.json
+++ b/game/data/dialogues/stage_3_game_over.json
@@ -1,0 +1,30 @@
+{
+	"bgm": "res://assets/sounds/game_over.ogg",
+	"dialogue": [
+		{
+			"text": "너...",
+			"character": "res://assets/images/stage_3/game_over.png"
+		},
+		
+		{
+			"text": "넌...",
+			"character": "res://assets/images/stage_3/game_over.png"
+		},
+		
+		{
+			"text": "근육을...",
+			"character": "res://assets/images/stage_3/game_over.png"
+		},
+		
+		{
+			"text": "가질...",
+			"character": "res://assets/images/stage_3/game_over.png"
+		},
+		
+		{
+			"text": "자격 없어...",
+			"character": "res://assets/images/stage_3/game_over.png",
+			"end": true
+		}
+	]
+}

--- a/game/data/dialogues/stage_3_intro.json
+++ b/game/data/dialogues/stage_3_intro.json
@@ -1,0 +1,39 @@
+{
+	"bgm": "res://assets/sounds/intro.ogg",
+	"dialogue": [
+		{
+			"text": "'이름 모를 트레이너는 화를 내며 헬스장을 뛰쳐나갔다'",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "' 도대체.. 정상적인 사람은 없는 건가...?'",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "후우... 하아...",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "(...? 무슨 소리지?)",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "하아... 너무 좋아.",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "하... 하나... 하나만 더.",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "(나가야겠다! 이곳은 위험해!)",
+			"background": "res://assets/images/shared/background_main.png"
+		}
+	]
+}

--- a/game/data/dialogues/stage_3_main.json
+++ b/game/data/dialogues/stage_3_main.json
@@ -1,0 +1,104 @@
+{
+	"bgm": "res://assets/sounds/battle_default.ogg",
+	"dialogue": [
+		{
+			"text": "헉... 두 개... 으응...",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/default.png",
+			
+		},
+		{
+			"text": "(위험하다... 너무 위험하다... 가까이 가지도 말자...)",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/default.png"
+		},
+
+		{
+			"text": "거기... 너... 하체... 해라...",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/angry.png",
+			"emotion_expected": "happy", 
+			"failure_text": "내가... 도와주겠다..."
+		},
+
+
+		{
+			"text": "나... 간수치... 800.",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/angry.png",
+			"emotion_expected": "sad", 
+			"failure_text": "비웃지... 마라... 멸치..."
+		},
+
+		{
+			"text": "내... 다리... 만져 보겠나…",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/angry.png",
+			"emotion_expected": "happy", 
+			"failure_text": ".. 만져... 만져줘... 내... 근육..."
+		},
+
+		{
+			"text": "이제... 날 보조 해라...",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/angry.png",
+			"emotion_expected": "happy", 
+			"failure_text": "쇠질... 진심으로... 대하라..."
+		},
+		
+		{
+			"text": "유산소.. 하는가...",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/angry.png",
+			"emotion_expected": "happy", 
+			"failure_text": "으아아아아!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+		},
+
+		{
+			"text": "하아... 느끼고 있군...",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/angry.png"
+		},
+		
+		{
+			"text": "충분히... 느껴라... 난... 더 음미하러 간다...",
+			"background": "res://assets/images/shared/background_main.png",
+			"character": "res://assets/images/stage_3/angry.png"
+		}
+	]
+}

--- a/game/data/dialogues/stage_4_game_over.json
+++ b/game/data/dialogues/stage_4_game_over.json
@@ -1,0 +1,20 @@
+{
+	"bgm": "res://assets/sounds/game_over.ogg",
+	"dialogue": [
+		{
+			"text": "너 같은 놈한테 이 닭가슴살은 사치야...",
+			"background": "res://assets/images/stage_4/angry.png"
+		},
+		
+		{
+			"text": "내",
+			"background": "res://assets/images/stage_4/angry.png"
+		},
+		
+		{
+			"text": "놔",
+			"background": "res://assets/images/stage_4/angry.png",
+			"end": true
+		}
+	]
+}

--- a/game/data/dialogues/stage_4_intro.json
+++ b/game/data/dialogues/stage_4_intro.json
@@ -1,0 +1,19 @@
+{
+	"bgm": "res://assets/sounds/intro.ogg",
+	"dialogue": [
+		{
+			"text": "(...)",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "(이곳에 더 있으면 아무것도 못 할 것 같다...)",
+			"background": "res://assets/images/shared/background_main.png"
+		},
+		
+		{
+			"text": "(그냥 나가서 걷자...)",
+			"background": "res://assets/images/shared/background_main.png"
+		}
+	]
+}

--- a/game/data/dialogues/stage_4_main.json
+++ b/game/data/dialogues/stage_4_main.json
@@ -1,0 +1,159 @@
+{
+	"bgm": "res://assets/sounds/battle_boss.ogg",
+	"dialogue": [
+		{
+			"text": "하하하하하하 하하하하하하 하하하하하하",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+
+		{
+			"text": "(뭐지...? 저건... 인간이 맞나?)",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+		
+		{
+			"text": "하하하하하하 하하하하하하 하하하하하하",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+
+		{
+			"text": "(비위 맞춰서 웃어줘야겠다...)",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+
+		{
+			"text": "감히 최강을 공감하려 하는가!!!!!!!",
+			"background": "res://assets/images/stage_4/angry.png"
+		},
+
+		{
+			"text": "[※ 상황과 정반대의 표정을 지어야 보스를 클리어 할 수 있습니다! 목숨은 한 번 남았어요!]",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+
+		{
+			"text": "목숨이 아깝지 않은 가 보군..",
+			"background": "res://assets/images/stage_4/angry.png"
+		},
+
+		{
+			"text": "(유산소 하러 왔는데 목숨까지...?)",
+			"background": "res://assets/images/stage_4/angry.png"
+		},
+
+		{
+			"text": "얼어 붙어 아무말도 못하는거냐!! 크하하하하하하",
+			"background": "res://assets/images/stage_4/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/stage_4/angry.png",
+			"emotion_expected": "happy", 
+			"failure_text": "눈치나 보는 나약한놈... 단백질은 네놈에게 과분하다.",
+		},
+
+		{
+			"text": "내 앞에서 웃을 수 있다니 재미있는 놈이구나",
+			"background": "res://assets/images/stage_4/default.png",
+		},
+
+		{
+			"text": "날 대적할 상대는 내 아들 뿐이다.",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+		
+		{
+			"text": "바킈... 라는 녀석이지...",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+		{
+			"text": "창피한 얘기지만... 난 아들과의 싸움에서 비겼다...",
+			"background": "res://assets/images/stage_4/default.png",
+		},
+		{
+			"text": "이런 내가 한심해 보이는가...?",
+			"background": "res://assets/images/stage_4/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/stage_4/angry.png",
+			"emotion_expected": "happy", 
+			"failure_text": "네게 동정 받을 정도로 약하지 않다! 발끝으로 매달리지 못하는 자... 한심하군."
+		},
+
+		{
+			"text": "(어떤 아들이길래... 저런 사람과 비긴다는 거지...?)",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+		
+		{
+			"text": "여자친구랑 있다가 나한테 걸린 적이 있지... 후후!",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+		
+		{
+			"text": "같이 놀자고 하니 기겁을 하더군. 애비 마음도 모르고 말이야!",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+		
+		{
+			"text": "나 같은 아빠가 있으면 얼마나 좋아! 그렇지 않나?",
+			"background": "res://assets/images/stage_4/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/stage_4/angry.png",
+			"emotion_expected": "sad", 
+			"failure_text": "웃어? 부모님한테 잘 해, 임마!"
+		},
+		
+		{
+			"text": "(눈치가 없는 아빠가 확실하다.)",
+			"background": "res://assets/images/stage_4/default.png"
+		},
+		
+		{
+			"text": "너 좀전에 웃는 얼굴이 아주 매력적이군! 동안이란 소리 자주 듣지?",
+			"background": "res://assets/images/stage_4/default.png",
+			"timer": true
+		},
+
+		{
+			"text": "[표정을 응시한다.]",
+			"background": "res://assets/images/stage_4/angry.png",
+			"emotion_expected": "sad", 
+			"failure_text": "이 나를 앞에 두고 웃다니 건방진 녀석!!",
+		},
+
+		{
+			"text": "이런 보잘 것 없는 도시에서 꽤 쓸만한 놈을 만났군.",
+			"background": "res://assets/images/stage_4/default.png",
+		},
+
+		{
+			"text": "넌 더 강해질거다.",
+			"background": "res://assets/images/stage_4/default.png",
+		},
+
+		{
+			"text": "(... 공원에서 저러고 있으면 안잡아가나...?)",
+			"background": "res://assets/images/stage_4/default.png",
+		},
+		
+		{
+			"text": "(엇, 사라졌다)",
+			"background": "res://assets/images/stage_4/background.png",
+		},
+
+		{
+			"text": "(피곤하다... 그냥 집이나 가자.)",
+			"background": "res://assets/images/stage_4/background.png",
+		}
+	]
+}

--- a/game/data/dialogues/stage_5_intro.json
+++ b/game/data/dialogues/stage_5_intro.json
@@ -1,0 +1,74 @@
+{
+	"bgm": "res://assets/sounds/ending.ogg",
+	"dialogue": [
+		{   
+			"text": " ",
+			"background": "res://assets/images/ending/1.png"
+		},
+
+		{
+			"text": " ",
+			"background": "res://assets/images/ending/2.png"
+		},
+		
+		{
+			"text": " ",
+			"background": "res://assets/images/ending/3.png"
+		},
+		
+		{
+			"text": " ",
+			"background": "res://assets/images/ending/4.png"
+		},
+		
+		{
+			"text": " ",
+			"background": "res://assets/images/ending/5.png"
+		},
+		
+		{
+			"text": " ",
+			"background": "res://assets/images/ending/6.png"
+		},
+		
+		{
+			"text": " ",
+			"background": "res://assets/images/ending/7.png"
+		},
+
+		{
+			"text": "(후... 오늘은 이쯤 할까)",
+			"background": "res://assets/images/ending/7.png"
+		},
+		
+		{
+			"text": "(이 헬스장 다닌지도 벌써 1년이네)",
+			"background": "res://assets/images/ending/7.png"
+		},
+
+		{
+			"text": "(이 정도 몸이면 바디 프로필을 찍어도 되겠어)",
+			"background": "res://assets/images/ending/7.png"
+		},
+
+		{
+			"text": "(집이나 가자)",
+			"background": "res://assets/images/ending/7.png"
+		},
+		
+		{
+			"text": " ",
+			"background": "res://assets/images/ending/8.png"
+		},
+		
+		{
+			"text": "(우편이 왔네?)",
+			"background": "res://assets/images/ending/9.png"
+		},
+		
+		{
+			"text": "(어......?)",
+			"background": "res://assets/images/ending/10.png",
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Per-stage dialogue data

## Changes
- Add stage 0-5 intro/main/game_over JSON files under `game/data/dialogues/`

## Related Issue
Closes #35

## Notes
- Adding a new stage is a pure JSON change

## Test
- [ ] `dialogue.gd` loads every file without schema errors
