### PR TITLE
chore(models): add models/ directory for weights

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,6 @@
+# Models
+
+Place model weights here (gitignored):
+
+- `yolo.onnx` — face detector (referenced by `DETECTOR_PATH`).
+- `efficientnet_b3.pth` — emotion classifier weights (referenced by `CLASSIFIER_WEIGHT_PATH`).


### PR DESCRIPTION
## Summary
- `models/` directory for weight files

## Changes
- Add `models/README.md` documenting expected files (`yolo.onnx`, `efficientnet_b3.pth`)

## Related Issue
Closes #38

## Notes
- Weights remain gitignored; README tells contributors what to drop in

## Test
- [ ] `make server` starts end-to-end once weights are in place
- [ ] Weights are never tracked
